### PR TITLE
ci: add PR workflow with lint/tests and image release

### DIFF
--- a/.github/workflows/pull-ci.yml
+++ b/.github/workflows/pull-ci.yml
@@ -1,0 +1,92 @@
+name: Pull CI
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Run lint and tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services: # database setup for integration and e2e tests
+      postgres:
+        image: docker.io/postgres:15
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Ruff lint
+        run: ruff check
+
+      - name: Ruff format check
+        run: ruff format --check
+
+      - name: Mypy type tests
+        run: mypy --ignore-missing-imports --explicit-package-bases .
+
+      - name: Run unit tests
+        run: |
+          cd tests/unit; PYTHONPATH=../..: pytest --cov=lufa -v
+
+      - name: Run integration tests
+        run: |
+          cd tests/integration; PYTHONPATH=../..: pytest --cov=lufa -v
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: secret
+
+      - name: Run e2e tests
+        run: |
+          cd tests/e2e; PYTHONPATH=../..: pytest --cov=lufa -v
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: secret
+
+  docker_dry_run:
+    name: Docker build (dry run)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build without push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+on:
+  push:
+    branches:
+      - main # for nightly releases
+    tags:
+      - "v*"
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Get image tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_REF}" == refs/heads/main ]]; then
+            echo "tag=nightly" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get project version
+        id: project_version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/heads/main ]]; then
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "no_tag")
+            BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/\//-/g')
+            COMMIT=$(git rev-parse --short=8 HEAD)
+            VERSION="${TAG}-git.${BRANCH}.${COMMIT}"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set version in pyproject.toml
+        run: sed -i '/^\[project\]/,/^\[/s|version = "unknown-version"|version = "${{ steps.project_version.outputs.version }}"|' pyproject.toml
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      - name: Extract dist dir from image
+        shell: bash
+        run: |
+          docker create --name lufa ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          mkdir -p dist
+          docker cp lufa:/lufa/lufa/static/dist lufa/static/dist/
+          docker rm lufa
+
+      - name: Create dist archive
+        run: zip -r node_dist.zip lufa/static/dist
+
+      - name: Create nightly release
+        if: ${{ steps.tag.outputs.tag == 'nightly' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          
+          gh release delete nightly -y || :
+          git push --delete origin nightly || :
+          gh release create nightly \
+                  --target ${{ github.sha }} \
+                  --prerelease \
+                  --title "LUFA nightly build $(git show -s --format="%ci")" \
+                  --notes "Automatically built node js dists for Testing" \
+                  node_dist.zip
+
+      - name: Create release
+        if: ${{ steps.tag.outputs.tag != 'nightly' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          
+          gh release create ${{ steps.tag.outputs.tag }} \
+                  --title "LUFA Release ${{ steps.tag.outputs.tag }} ($(git show -s --format="%cs"))" \
+                  --generate-notes \
+                  node_dist.zip


### PR DESCRIPTION
Introduce a Pull CI GitHub Actions workflow that runs Ruff lint/format checks, mypy, unit/integration/e2e tests with a Postgres service, and a separate job to verify the Docker image builds (dry run without push).

Add a release workflow that builds and pushes images to GHCR for tags and main branch, injects the computed version into pyproject.toml, extracts the built frontend dist from the container and publishes it as a GitHub release asset (nightly or tagged release).