### PR TITLE
fix: lowercase repository for GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: Lowercase repository for Docker/GHCR
+        run: echo "REPOSITORY_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Get image tag
         id: tag
         run: |
@@ -60,15 +63,14 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ env.REPOSITORY_LC }}:${{ steps.tag.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
 
       - name: Extract dist dir from image
         shell: bash
         run: |
-          docker create --name lufa ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+          docker create --name lufa ghcr.io/${{ env.REPOSITORY_LC }}:${{ steps.tag.outputs.tag }}
           mkdir -p dist
           docker cp lufa:/lufa/lufa/static/dist lufa/static/dist/
           docker rm lufa


### PR DESCRIPTION
GHCR requires lowercase image names. Export REPOSITORY_LC from GITHUB_REPOSITORY and use it for build/push tags and docker create.