### PR TITLE
fix: resolve LDAP login JSON serialization errors

### DIFF
--- a/lufa/repository/user_repository.py
+++ b/lufa/repository/user_repository.py
@@ -28,7 +28,7 @@ class SqliteUserRepository(UserRepository):
     def save_user(self, username: str, distinguished_name: str, data: dict[str, str]) -> None:
         conn = self.db_manager.get_db_connection()
         cursor = conn.cursor()
-        data_json = json.dumps(data)
+        data_json = json.dumps(dict(data), default=str)
 
         cursor.execute(
             """
@@ -75,7 +75,7 @@ class PostgresUserRepository(UserRepository):
     def save_user(self, username: str, distinguished_name: str, data: dict[str, str]) -> None:
         conn = self.db_manager.get_db_connection()
         cursor = conn.cursor()
-        data_json = json.dumps(data)
+        data_json = json.dumps(dict(data), default=str)
 
         cursor.execute(
             """


### PR DESCRIPTION
Convert CaseInsensitiveDict to dict and handle datetime serialization in user repositories by adding dict() conversion and default=str parameter to json.dumps(). This fixes:
- TypeError: Object of type CaseInsensitiveDict is not JSON serializable
- TypeError: Object of type datetime is not JSON serializable