### PR TITLE
fix: Speedup v_host_templates from 2min to 1,3s

### DIFF
--- a/lufa/schema.sql
+++ b/lufa/schema.sql
@@ -4,6 +4,7 @@ DROP VIEW IF EXISTS v_host_templates_ordered;
 DROP VIEW IF EXISTS v_template_compliance;
 DROP VIEW IF EXISTS v_host_compliance;
 DROP VIEW IF EXISTS v_host_template_compliance;
+DROP INDEX IF EXISTS v_host_templates_index;
 DROP MATERIALIZED VIEW IF EXISTS v_host_templates;
 DROP VIEW IF EXISTS v_job_status;
 
@@ -152,6 +153,9 @@ CREATE MATERIALIZED VIEW v_host_templates AS
     ON stats.tower_job_id = jobs.tower_job_id
     JOIN job_templates
     ON jobs.tower_job_template_id = job_templates.tower_job_template_id;
+
+CREATE INDEX v_host_templates_index
+  ON v_host_templates (tower_job_template_id, ansible_host);
 
 CREATE VIEW v_host_template_compliance AS
 	SELECT

--- a/tests/integration/lufa/drop_tables.sql
+++ b/tests/integration/lufa/drop_tables.sql
@@ -5,6 +5,7 @@ DROP INDEX IF EXISTS task_callbacks_task_uuid CASCADE;
 DROP INDEX IF EXISTS task_callbacks_ansible_host_index CASCADE;
 DROP INDEX IF EXISTS task_callbacks_timestamp_index CASCADE;
 DROP INDEX IF EXISTS stats_ansible_host_index CASCADE;
+DROP INDEX IF EXISTS v_host_templates_index;
 
 DROP TRIGGER IF EXISTS delete_unreferenced_job_templates ON jobs;
 DROP FUNCTION IF EXISTS delete_unreferenced_job_templates();


### PR DESCRIPTION
on large Postgres DBs. In the end only a index was needed for the materialized view. This is most notable on the /api/compliance/host endpoint.