### PR TITLE
fix: keep job overview live refresh active for running jobs

### DIFF
--- a/lufa/templates/basic_job.html
+++ b/lufa/templates/basic_job.html
@@ -49,7 +49,7 @@
             ).done(function (data) {
                 jobState = data.state;
                 writeJobStatus(jobState.state);
-                if (jobState != "started") {
+                if (jobState.state !== "started") {
                     refresher.setEnabled(false);
                 }
             });


### PR DESCRIPTION
Compare the nested job status value instead of the full status object so the refresher is only disabled once the job is no longer started.