### PR TITLE
fix: display page titles correctly

### DIFF
--- a/lufa/templates/basic_job.html
+++ b/lufa/templates/basic_job.html
@@ -1,5 +1,6 @@
 {% extends "basic.html" %}
 
+{% block title %}Job {{ tower_job_id }}{% endblock %}
 {% block content %}
 
 <h1>Job {{ tower_job_id }} - {{ tower_job_template_name }}</h1>

--- a/lufa/templates/basic_template.html
+++ b/lufa/templates/basic_template.html
@@ -1,5 +1,6 @@
 {% extends "basic.html" %}
 
+{% block title %}Template {{ tower_job_template_id }}{% endblock %}
 {% block content %}
 
 <h1>Template {{ tower_job_template_id }} - {{ tower_job_template_name }}</h1>

--- a/lufa/templates/basic_workflow.html
+++ b/lufa/templates/basic_workflow.html
@@ -1,5 +1,6 @@
 {% extends "basic.html" %}
 
+{% block title %}Workflow {{ tower_workflow_job_id }}{% endblock %}
 {% block content %}
 
 <h1>Workflow {{ tower_workflow_job_id }} - {{ tower_workflow_job_name }}</h1>


### PR DESCRIPTION
Set the page title content so pages no longer
render only " - LUFA" in the browser title.