### PR TITLE
fix: render initial job status on page load

### DIFF
--- a/lufa/frontend.py
+++ b/lufa/frontend.py
@@ -52,9 +52,12 @@ def jobs_data():
 @login_required
 def job_recap(tower_job_id):
     """Renders the job recap page for the given job ID."""
+    initial_job_state = get_backend_repository().get_job_status(tower_job_id)["state"]
+
     return render_template(
         "job_recap.html",
         tower_job_id=tower_job_id,
+        initial_job_state=initial_job_state,
         tower_job_template_name=get_backend_repository().get_job_template_name_by_job_id(tower_job_id),
     )
 
@@ -74,9 +77,12 @@ def job_recap_data(tower_job_id):
 @login_required
 def job_callbacks(tower_job_id: int):
     """Renders the job callbacks page for the given job ID."""
+    initial_job_state = get_backend_repository().get_job_status(tower_job_id)["state"]
+
     return render_template(
         "job_callbacks.html",
         tower_job_id=tower_job_id,
+        initial_job_state=initial_job_state,
         tower_job_template_name=get_backend_repository().get_job_template_name_by_job_id(tower_job_id),
     )
 
@@ -98,9 +104,12 @@ def job_callbacks_data(tower_job_id: int):
 @login_required
 def job_hosts_overview(tower_job_id: int):
     """Renders the job overview page for the given job ID."""
+    initial_job_state = get_backend_repository().get_job_status(tower_job_id)["state"]
+
     return render_template(
         "job_overview.html",
         tower_job_id=tower_job_id,
+        initial_job_state=initial_job_state,
         tower_job_template_name=get_backend_repository().get_job_template_name_by_job_id(tower_job_id),
     )
 
@@ -152,9 +161,12 @@ def job_infos(tower_job_id: int):
     awx_template_link = current_app.config["AWX_BASE_URL"] + "/#/templates/job_template/" + str(tower_job_template_id)
     awx_job_link = current_app.config["AWX_BASE_URL"] + "/#/jobs/playbook/" + str(tower_job_id)
 
+    initial_job_state = get_backend_repository().get_job_status(tower_job_id)["state"]
+
     return render_template(
         "job_infos.html",
         tower_job_id=tower_job_id,
+        initial_job_state=initial_job_state,
         tower_job_template_name=get_backend_repository().get_job_template_name_by_job_id(tower_job_id),
         tower_job_template_id=tower_job_template_id,
         tower_user_name=tower_user_name,

--- a/lufa/repository/backend_repository.py
+++ b/lufa/repository/backend_repository.py
@@ -369,11 +369,14 @@ class SqliteBackendRepository(BackendRepository):
         )
 
         line = cursor.fetchone()
-        line["awx_tags"] = line["awx_tags"].split(",")
-        line["template_infos"] = line["template_infos"] = (
-            json.loads(line["template_infos"]) if line["template_infos"] else None
-        )
-        return line
+        if line is not None:
+            line["awx_tags"] = line["awx_tags"].split(",")
+            line["template_infos"] = line["template_infos"] = (
+                json.loads(line["template_infos"]) if line["template_infos"] else None
+            )
+            return line
+
+        raise ResourceNotFoundError(f"Job with id {tower_job_id} not found")
 
     def get_job_task_callbacks(self, tower_job_id: int) -> list[JobTaskCallbacks]:
         conn = self.db_manager.get_db_connection()
@@ -1011,7 +1014,11 @@ class PostgresBackendRepository(BackendRepository):
             (tower_job_id,),
         )
 
-        return cursor.fetchone()
+        fetched = cursor.fetchone()
+        if fetched is not None:
+            return fetched
+
+        raise ResourceNotFoundError(f"Job with id {tower_job_id} not found")
 
     def get_job_task_callbacks(self, tower_job_id: int) -> list[JobTaskCallbacks]:
         conn = self.db_manager.get_db_connection()

--- a/lufa/static/status-element.js
+++ b/lufa/static/status-element.js
@@ -19,9 +19,12 @@ function getStatusElement(state) {
         badge.className = 'badge';
         badge.innerHTML = 'error';
         badge.style.backgroundColor = 'purple';
-    } else {
+    } else if (state === 'failed') {
         badge.className = 'badge bg-danger';
         badge.innerHTML = 'failed';
+    } else {
+        badge.className = 'badge bg-secondary';
+        badge.innerHTML = 'unknown';
     }
     return badge;
 }

--- a/lufa/templates/basic_job.html
+++ b/lufa/templates/basic_job.html
@@ -40,6 +40,10 @@
 <script nonce="{{crp_nonce}}">
 
     $(document).ready(() => {
+        // set initial job state
+        let initialJobState = "{{ initial_job_state | default('unknown') }}";
+        writeJobStatus(initialJobState);
+
         globalThis.refresher.setUpdater(refresher => {
             let jobState = "";
 


### PR DESCRIPTION
Load the job status with the initial page render
and set the badge immediately, so the status is
visible even when live refresh is disabled.